### PR TITLE
Reintroduce hack for masthead in 1140 grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
-  
+
+## 0.2.1
+
+  * Reintroduced hack for masthead in 1140 grid
+
 ## 0.2.0
 
   * Updated to use `styles` directories over css/scss

--- a/src/styles/grid.scss
+++ b/src/styles/grid.scss
@@ -11,6 +11,12 @@ body {
   clear: left;
   overflow: visible;
 }
+
+.grid-1140 .skycom-container { //Hack for masthead
+  max-width: $container-width;
+}
+
+}
 .grid-974 .skycom-container{ //deprecate - for now, allow people to chose a smaller grid :(
   max-width: $container-width-thin;
 }


### PR DESCRIPTION
The masthead will not go full width when using the 1140 grid & the newest web-toolkit.

This hack that was removed in https://github.com/skyglobal/grid/commit/2bdd9375608a184b3f2864251013fd5829c27527 would fix this issue if the toolkit was updated to use this version of the grid.
